### PR TITLE
Fix missing server_address, port, and version fields in Telethon session files

### DIFF
--- a/TGConvertor/sessions/tele.py
+++ b/TGConvertor/sessions/tele.py
@@ -181,8 +181,14 @@ class TeleSession:
         ))
 
     async def to_file(self, path: Path):
+        if self.server_address is None:
+                self.server_address, self.port = DataCenter(
+                    self.dc_id, False, False, False
+                )
         async with aiosqlite.connect(path) as db:
             await db.executescript(SCHEMA)
+            await db.commit()
+            await db.execute("INSERT INTO version (version) VALUES (?)", (7,))
             await db.commit()
             sql = "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)"
             params = (


### PR DESCRIPTION
### Description
This pull request addresses an issue in the to_telethon_file() method of the SessionManager class, where:

- The version field in the session database was left empty.

- The server_address and port fields were missing from the session data.

These issues caused the generated Telethon session files to be invalid, resulting in connection failures.

### Changes

- Added logic to automatically insert the version value as 7 when writing the session data.

- Ensured that the server_address and port fields are correctly set if they are missing.

### Testing

- Converted multiple Pyrogram string sessions to Telethon session files.

- Verified that the generated .session files now include the required version, server_address, and port fields.

- Successfully connected the Telethon client using the updated session files.



Thank you for maintaining this helpful library! 😊